### PR TITLE
switch to event-sourcing based data model

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     ]
   },
   "dependencies": {
+    "@typegoose/auto-increment": "^0.6.0",
     "@typegoose/typegoose": "^7.4.1",
     "apollo-server-express": "^2.18.1",
     "class-validator": "^0.12.2",

--- a/schema.graphql
+++ b/schema.graphql
@@ -5,15 +5,15 @@
 
 type Mutation {
   """Add a single view to the target video's count"""
-  addVideoView(videoID: ID!): VideoViewsInfo!
+  addVideoView(channelId: ID!, videoId: ID!): VideoViewsInfo!
 }
 
 type Query {
   """Get views counts for a list of videos"""
-  batchedVideoViews(videoIDList: [ID!]!): [VideoViewsInfo]!
+  batchedVideoViews(videoIdList: [ID!]!): [VideoViewsInfo]!
 
   """Get views count for a single video"""
-  videoViews(videoID: ID!): VideoViewsInfo
+  videoViews(videoId: ID!): VideoViewsInfo
 }
 
 type VideoViewsInfo {

--- a/src/aggregate.ts
+++ b/src/aggregate.ts
@@ -1,0 +1,46 @@
+import { VideoEvent, VideoEventsBucketModel, VideoEventType } from './models/VideoEvent'
+
+export class VideoAggregate {
+  private videoViewsMap: Record<string, number> = {}
+  private channelViewsMap: Record<string, number> = {}
+
+  public videoViews(videoId: string): number {
+    return this.videoViewsMap[videoId] || 0
+  }
+
+  public channelViews(channelId: string): number {
+    return this.channelViewsMap[channelId] || 0
+  }
+
+  public async rebuild() {
+    const aggregation = (await VideoEventsBucketModel.aggregate([
+      { $unwind: '$events' },
+      { $group: { _id: null, allEvents: { $push: '$events' } } },
+      { $project: { events: '$allEvents' } },
+    ])) as { events: VideoEvent[] }[]
+
+    aggregation[0].events.forEach((event) => {
+      this.applyEvent(event)
+    })
+  }
+
+  public applyEvent(event: VideoEvent) {
+    switch (event.eventType) {
+      case VideoEventType.AddView:
+        this.applyAddViewEvent(event)
+        break
+      default:
+        console.error(`Parsing unknown video event: ${event.eventType}`)
+    }
+  }
+
+  private applyAddViewEvent(event: VideoEvent) {
+    const currentVideoViews = this.videoViewsMap[event.videoId] || 0
+    const currentChannelViews = this.channelViewsMap[event.channelId] || 0
+
+    this.videoViewsMap[event.videoId] = currentVideoViews + 1
+    this.channelViewsMap[event.videoId] = currentChannelViews + 1
+  }
+}
+
+export const videoAggregate = new VideoAggregate()

--- a/src/entities/VideoViewsInfo.ts
+++ b/src/entities/VideoViewsInfo.ts
@@ -1,15 +1,10 @@
 import { Field, ID, Int, ObjectType } from 'type-graphql'
-import { getModelForClass, prop } from '@typegoose/typegoose'
 
 @ObjectType()
 export class VideoViewsInfo {
   @Field(() => ID, { name: 'id' })
-  @prop({ required: true, index: true })
-  videoID: string
+  videoId: string
 
   @Field(() => Int)
-  @prop({ required: true, default: 0 })
   views: number
 }
-
-export const VideoViewsInfoModel = getModelForClass(VideoViewsInfo)

--- a/src/models/VideoEvent.ts
+++ b/src/models/VideoEvent.ts
@@ -1,0 +1,73 @@
+import { getModelForClass, plugin, prop } from '@typegoose/typegoose'
+import { AutoIncrementID } from '@typegoose/auto-increment'
+
+const MAX_BUCKET_SIZE = 50000
+
+export enum VideoEventType {
+  AddView = 'ADD_VIEW',
+}
+
+export class VideoEvent {
+  @prop({ required: true, index: true, unique: true })
+  eventId?: number
+
+  @prop({ required: true, index: true })
+  videoId: string
+
+  @prop({ required: true, index: true })
+  channelId: string
+
+  timestamp: Date
+
+  @prop({ required: true, index: true, enum: VideoEventType })
+  eventType: VideoEventType
+}
+
+@plugin(AutoIncrementID, { field: 'bucketId' })
+class VideoEventsBucket {
+  @prop({ required: true, index: true, unique: true })
+  bucketId?: number
+
+  @prop({ required: true, index: true })
+  firstTimestamp: Date
+
+  @prop({ required: true, index: true })
+  lastTimestamp: Date
+
+  @prop({ required: true })
+  bucketSize: number
+
+  @prop({ required: true, type: () => [VideoEvent] })
+  events: VideoEvent[]
+}
+
+export const VideoEventsBucketModel = getModelForClass(VideoEventsBucket, {
+  schemaOptions: { collection: 'videoEvents' },
+})
+
+export const insertVideoEventIntoBucket = async (event: VideoEvent) => {
+  // TODO: possibly cache the last bucket
+  const lastBucket = await VideoEventsBucketModel.findOne().sort({ bucketId: -1 })
+  const lastEventId = lastBucket ? lastBucket.events[lastBucket.events.length - 1].eventId || 0 : 0
+  event.eventId = lastEventId + 1
+
+  if (!lastBucket || lastBucket.bucketSize >= MAX_BUCKET_SIZE) {
+    return await createNewBucketFromEvent(event)
+  }
+
+  lastBucket.events.push(event)
+  lastBucket.bucketSize++
+  lastBucket.lastTimestamp = event.timestamp
+  await lastBucket.save()
+}
+
+const createNewBucketFromEvent = async (event: VideoEvent) => {
+  const newBucket: VideoEventsBucket = {
+    firstTimestamp: event.timestamp,
+    lastTimestamp: event.timestamp,
+    bucketSize: 1,
+    events: [event],
+  }
+
+  await VideoEventsBucketModel.create(newBucket)
+}

--- a/src/resolvers/videoViewsInfos.ts
+++ b/src/resolvers/videoViewsInfos.ts
@@ -1,49 +1,74 @@
 import { Args, ArgsType, Field, ID, Mutation, Query, Resolver } from 'type-graphql'
-import { VideoViewsInfo, VideoViewsInfoModel } from '../entities/VideoViewsInfo'
+import { VideoViewsInfo } from '../entities/VideoViewsInfo'
+import { videoAggregate } from '../aggregate'
+import { insertVideoEventIntoBucket, VideoEvent, VideoEventType } from '../models/VideoEvent'
 
 @ArgsType()
 class VideoViewsArgs {
   @Field(() => ID)
-  videoID: string
+  videoId: string
 }
 
 @ArgsType()
 class BatchedVideoViewsArgs {
   @Field(() => [ID])
-  videoIDList: string[]
+  videoIdList: string[]
 }
 
 @ArgsType()
 class AddVideoViewArgs {
   @Field(() => ID)
-  videoID: string
+  videoId: string
+
+  @Field(() => ID)
+  channelId: string
 }
 
 @Resolver()
 export class VideoViewsInfosResolver {
   @Query(() => VideoViewsInfo, { nullable: true, description: 'Get views count for a single video' })
-  async videoViews(@Args() { videoID }: VideoViewsArgs) {
-    return VideoViewsInfoModel.findOne({ videoID: videoID })
+  async videoViews(@Args() { videoId }: VideoViewsArgs): Promise<VideoViewsInfo | null> {
+    const views = videoAggregate.videoViews(videoId)
+    if (views) {
+      return {
+        videoId,
+        views,
+      }
+    }
+    return null
   }
 
   @Query(() => [VideoViewsInfo], { description: 'Get views counts for a list of videos', nullable: 'items' })
-  async batchedVideoViews(@Args() { videoIDList }: BatchedVideoViewsArgs) {
-    const results = await VideoViewsInfoModel.find({
-      videoID: {
-        $in: videoIDList,
-      },
+  async batchedVideoViews(@Args() { videoIdList }: BatchedVideoViewsArgs): Promise<(VideoViewsInfo | null)[]> {
+    return videoIdList.map((videoId) => {
+      const videoViews = videoAggregate.videoViews(videoId)
+      if (videoViews) {
+        const videoViewsInfo: VideoViewsInfo = {
+          videoId,
+          views: videoViews,
+        }
+        return videoViewsInfo
+      }
+      return null
     })
-
-    const resultsLookup = results.reduce((acc, result) => {
-      acc[result.videoID] = result
-      return acc
-    }, {} as Record<string, VideoViewsInfo>)
-
-    return videoIDList.map((id) => resultsLookup[id] || null)
   }
 
   @Mutation(() => VideoViewsInfo, { description: "Add a single view to the target video's count" })
-  async addVideoView(@Args() { videoID }: AddVideoViewArgs) {
-    return VideoViewsInfoModel.findOneAndUpdate({ videoID }, { $inc: { views: 1 } }, { new: true, upsert: true })
+  async addVideoView(@Args() { videoId, channelId }: AddVideoViewArgs): Promise<VideoViewsInfo> {
+    const event: VideoEvent = {
+      videoId,
+      channelId,
+      eventType: VideoEventType.AddView,
+      timestamp: new Date(),
+    }
+
+    await insertVideoEventIntoBucket(event)
+    videoAggregate.applyEvent(event)
+
+    const views = videoAggregate.videoViews(videoId)
+    return {
+      videoId,
+      views,
+    }
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,14 +5,27 @@ import { connect } from 'mongoose'
 import { buildSchema } from 'type-graphql'
 import { VideoViewsInfosResolver } from './resolvers/videoViewsInfos'
 import config from './config'
+import { videoAggregate } from './aggregate'
 
 const main = async () => {
+  await getMongooseConnection()
+  await rebuildAggregates()
+
   const schema = await buildSchema({
     resolvers: [VideoViewsInfosResolver],
     emitSchemaFile: 'schema.graphql',
-    validate: true,
+    validate: false,
   })
 
+  const server = new ApolloServer({ schema })
+  const app = Express()
+  server.applyMiddleware({ app })
+  app.listen({ port: config.port }, () =>
+    console.log(`🚀 Server listening at ==> http://localhost:${config.port}${server.graphqlPath}`)
+  )
+}
+
+const getMongooseConnection = async () => {
   process.stdout.write(`Connecting to MongoDB at "${config.mongoDBUri}"...`)
   try {
     const mongoose = await connect(config.mongoDBUri, {
@@ -28,13 +41,19 @@ const main = async () => {
     return
   }
   process.stdout.write(' Done.\n')
+}
 
-  const server = new ApolloServer({ schema })
-  const app = Express()
-  server.applyMiddleware({ app })
-  app.listen({ port: config.port }, () =>
-    console.log(`🚀 Server listening at ==> http://localhost:${config.port}${server.graphqlPath}`)
-  )
+const rebuildAggregates = async () => {
+  process.stdout.write('Rebuilding video events aggregate...')
+  try {
+    await videoAggregate.rebuild()
+  } catch (error) {
+    process.stdout.write(' Failed!\n')
+    console.error(error)
+    process.exit()
+    return
+  }
+  process.stdout.write(' Done.\n')
 }
 
 main()

--- a/yarn.lock
+++ b/yarn.lock
@@ -168,6 +168,14 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
+"@typegoose/auto-increment@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@typegoose/auto-increment/-/auto-increment-0.6.0.tgz#d4a4dbd23038cffc5a959c7dc38bddbb578a572e"
+  integrity sha512-LLRJ7CoUbcRHtRUDhHV8g6KFhiR72VdYH24kgUa6cXRIDpB8rawIbyr5eZzd/2s7mrKyNtfpTlnJAjw5ZaIGYg==
+  dependencies:
+    loglevel "^1.7.0"
+    tslib "^2.0.3"
+
 "@typegoose/typegoose@^7.4.1":
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/@typegoose/typegoose/-/typegoose-7.4.1.tgz#a125d6bcf146b2353e62ed080b38a38d8ea4eb0d"
@@ -3605,6 +3613,11 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
+tslib@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
+  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
 
 tsutils@^3.17.1:
   version "3.17.1"


### PR DESCRIPTION
This PR resolves #1 by switching Orion data model to be event-based. To ensure decent performance two approaches were used:

### Event sourcing
Our implementation is pretty loosely based on event sourcing. It doesn't follow it strictly as our use-case is pretty narrow and simple at this point. We save sequenced events to MongoDB, which can be used to build the aggregate (current state). For performance, we keep the full aggregate in memory so that most basic queries will not require any DB lookup at all. The aggregate is built upon Orion launch by parsing all the existing events. This approach should be pretty extensible in the future. Building on top of this to e.g. save channel follow/unfollow events should be fairly simple.

### Time-series data / size-based buckets
Using the most straight-forward approach of one Mongo document per event could make us end up with _a lot_ of documents pretty fast. While there are reported cases of collections with billions of documents, it can potentially hurt performance. To alleviate that, size-based buckets were used - event buckets are created that (currently) hold up to 50,000 events as nested objects. This way we reduce the number of documents, while allowing fast reads of events from one document.

## Performance considerations
From what I gather, the current approach should allow us to handle foreseeable traffic no problem. It's not a perfect solution - it would probably break quite quickly when used with Youtube-like number of request. However, I figure we will need to implement different solution for view counts anyway until we get to traffic this implementation shouldn't be able to handle.