### PR TITLE
Fix issue with incorrect order in mostViewedVideos

### DIFF
--- a/src/server-extension/resolvers/baseTypes.ts
+++ b/src/server-extension/resolvers/baseTypes.ts
@@ -48,7 +48,9 @@ export class Membership {
 }
 
 export enum VideoOrderByInput {
-  id_ASC,
+  id_ASC = 'id_ASC',
+  viewsNum_ASC = 'viewsNum_ASC',
+  viewsNum_DESC = 'viewsNum_DESC',
 }
 registerEnumType(VideoOrderByInput, { name: 'VideoOrderByInput' })
 


### PR DESCRIPTION
Fix https://github.com/Joystream/atlas/issues/4109

This PR should fix the issue of showing videos in incorrect order when the `periodDays` argument is provided. 

The previous approach did not work correctly because every time we asked for popular movies by a given period, we sent two queries to the database. In the first one, we correctly obtained a list of video IDs in the correct order. However, after we received the correct list of movie IDs, we fired another query that sorted those movies by all views in total.
