### PR TITLE
Fix SQL error, when running mostViewedVideosConnection query

### DIFF
--- a/src/server-extension/resolvers/VideosResolver/index.ts
+++ b/src/server-extension/resolvers/VideosResolver/index.ts
@@ -151,9 +151,15 @@ export class VideosResolver {
       const arrayPosition = `array_position(
         array[${ids.map((id) => `'${id}'`).join(', ')}],
         video.id  
-      ) ASC`
-      connectionQuerySql = connectionQuerySql.replace('"video"."views_num" DESC', arrayPosition)
-      connectionQuerySql = connectionQuerySql.replace('"video"."views_num" ASC', arrayPosition)
+      )`
+      connectionQuerySql = connectionQuerySql.replace(
+        '"video"."views_num" DESC',
+        `${arrayPosition} ASC`
+      )
+      connectionQuerySql = connectionQuerySql.replace(
+        '"video"."views_num" ASC',
+        `${arrayPosition} DESC`
+      )
     }
 
     // Override the raw `sql` string in `connectionQuery` with the modified query

--- a/src/server-extension/resolvers/VideosResolver/index.ts
+++ b/src/server-extension/resolvers/VideosResolver/index.ts
@@ -116,15 +116,9 @@ export class VideosResolver {
           : ''),
       ''
     )
-    const viewsOrder =
-      args.orderBy.find((orderBy) => orderBy.startsWith('viewsNum_'))?.split('_')?.[1] || 'DESC'
 
     idsQuerySql = overrideClause(idsQuerySql, 'GROUP BY', '"video"."id"')
-    idsQuerySql = overrideClause(
-      idsQuerySql,
-      'ORDER BY',
-      `COUNT("video_view_event"."id") ${viewsOrder}`
-    )
+    idsQuerySql = overrideClause(idsQuerySql, 'ORDER BY', `COUNT("video_view_event"."id") DESC`)
     idsQuerySql = overrideClause(idsQuerySql, 'SELECT', '"video"."id"')
     idsQuerySql = overrideClause(idsQuerySql, 'LIMIT', `${args.limit}`)
 

--- a/src/server-extension/resolvers/VideosResolver/index.ts
+++ b/src/server-extension/resolvers/VideosResolver/index.ts
@@ -118,7 +118,7 @@ export class VideosResolver {
     )
 
     idsQuerySql = overrideClause(idsQuerySql, 'GROUP BY', '"video"."id"')
-    idsQuerySql = overrideClause(idsQuerySql, 'ORDER BY', `COUNT("video_view_event"."id") DESC`)
+    idsQuerySql = overrideClause(idsQuerySql, 'ORDER BY', 'COUNT("video_view_event"."id") DESC')
     idsQuerySql = overrideClause(idsQuerySql, 'SELECT', '"video"."id"')
     idsQuerySql = overrideClause(idsQuerySql, 'LIMIT', `${args.limit}`)
 


### PR DESCRIPTION
Fix https://github.com/Joystream/atlas/issues/4158

We were getting the error ` "common column name \"id\" appears more than once in left table",` once we were adding channel fields to the query.
I fixed the issue and refactored this a bit. Replaced `unnest()` with ` array_position()`which seems to me more straightforward, readable, and understandable. 