### PR TITLE
OffchainState fix: Batch inserts during import to avoid query errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orion",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "orion",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "hasInstallScript": true,
       "dependencies": {
         "@joystream/js": "^1.4.0",


### PR DESCRIPTION
When trying to execute migration script on production there was an error when trying to import video views, as the number of entities was very large (> 10k) and there was only a single query trying to insert them all into the database.