### PR TITLE
Add `auction_type` and `member_metadata_avatar` indexes

### DIFF
--- a/db/migrations/2100000000000-Indexes.js
+++ b/db/migrations/2100000000000-Indexes.js
@@ -25,8 +25,9 @@ module.exports = class Indexes2000000000000 {
       `CREATE INDEX "events_previous_nft_owner_channel" ON "processor"."event" USING BTREE (("data"->'previousNftOwner'->>'channel'));`
     )
     await db.query(`CREATE INDEX "events_buyer" ON "processor"."event" USING BTREE (("data"->>'buyer'));`)
-    await db.query(`CREATE INDEX "auction_type" ON "processor"."auction" USING BTREE (("auction_type" ->> 'isTypeOf'));`)
-    await db.query(`CREATE INDEX "member_metadata_avatar" ON "member_metadata" USING BTREE (("avatar" ->> 'avatarObject'));`)
+    await db.query(`CREATE INDEX "auction_type" ON "processor"."auction" USING BTREE (("auction_type"->>'isTypeOf'));`)
+    await db.query(`CREATE INDEX "member_metadata_avatar" ON "member_metadata" USING BTREE (("avatar"->>'avatarObject'));`)
+    await db.query(`CREATE INDEX "owned_nft_auction" ON "processor"."owned_nft" USING BTREE (("transactional_status"->>'auction'));`)
   }
 
   async down(db) {

--- a/db/migrations/2100000000000-Indexes.js
+++ b/db/migrations/2100000000000-Indexes.js
@@ -25,6 +25,8 @@ module.exports = class Indexes2000000000000 {
       `CREATE INDEX "events_previous_nft_owner_channel" ON "processor"."event" USING BTREE (("data"->'previousNftOwner'->>'channel'));`
     )
     await db.query(`CREATE INDEX "events_buyer" ON "processor"."event" USING BTREE (("data"->>'buyer'));`)
+    await db.query(`CREATE INDEX "auction_type" ON "processor"."auction" USING BTREE (("auction_type" ->> 'isTypeOf'));`)
+    await db.query(`CREATE INDEX "member_metadata_avatar" ON "member_metadata" USING BTREE (("avatar" ->> 'avatarObject'));`)
   }
 
   async down(db) {

--- a/db/postgres.conf
+++ b/db/postgres.conf
@@ -1,4 +1,6 @@
 listen_addresses = '*'
 log_statement = all
 autovacuum_analyze_scale_factor = 0.01
-shared_buffers=1GB
+shared_buffers=2GB
+jit=off
+random_page_cost=1.0


### PR DESCRIPTION
Fixes issues with long `ownedNftConnection` and `videoConnection` queries (improvements of over 10x) by adding some useful PostgreSQL indexes.
Addresses https://github.com/Joystream/atlas/issues/4227