### PR TITLE
[Nara] remove mappings for 'VideoDeletedByModerator' & 'ChannelDeletedByModerator' events

### DIFF
--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -78,11 +78,13 @@ export const eventConstructors = {
   'Content.VideoCreated': ContentVideoCreatedEvent,
   'Content.VideoUpdated': ContentVideoUpdatedEvent,
   'Content.VideoDeleted': ContentVideoDeletedEvent,
+  // Deprecated in runtime spec version 2002 (nara), but still required for Orion processing from genesis block
   'Content.VideoDeletedByModerator': ContentVideoDeletedByModeratorEvent,
   'Content.VideoVisibilitySetByModerator': ContentVideoVisibilitySetByModeratorEvent,
   'Content.ChannelCreated': ContentChannelCreatedEvent,
   'Content.ChannelUpdated': ContentChannelUpdatedEvent,
   'Content.ChannelDeleted': ContentChannelDeletedEvent,
+  // Deprecated in runtime spec version 2002 (nara), but still required for Orion processing from genesis block
   'Content.ChannelDeletedByModerator': ContentChannelDeletedByModeratorEvent,
   'Content.ChannelVisibilitySetByModerator': ContentChannelVisibilitySetByModeratorEvent,
   'Content.ChannelOwnerRemarked': ContentChannelOwnerRemarkedEvent,


### PR DESCRIPTION
addresses #113

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1204404358291458/1205517370057901) by [Unito](https://www.unito.io)
