### PR TITLE
fix: comment id not added to notification data

### DIFF
--- a/src/mappings/content/commentsAndReactions.ts
+++ b/src/mappings/content/commentsAndReactions.ts
@@ -525,6 +525,7 @@ export async function processCreateCommentMessage(
         videoId: video.id,
         videoTitle: parseVideoTitle(video),
         memberHandle: authorHandle,
+        comentId: comment.id,
       }
       await addNotification(
         overlay,

--- a/src/tests/integration/testUtils.ts
+++ b/src/tests/integration/testUtils.ts
@@ -65,6 +65,7 @@ export async function populateDbWithSeedData() {
     })
     const video = new Video({
       id: i.toString(),
+      title: `test-video-${i}`,
       createdAt: new Date(),
       channelId: channel.id,
       isCensored: false,


### PR DESCRIPTION
fixes: the issue related to
```
{"level":5,"time":1697443321233,"ns":"sqd:processor","err":{"generatedMessage":false,"code":"ERR_ASSERTION","actual":false,"expected":true,"operator":"==","stack":"AssertionError [ERR_ASSERTION]: uninitialized access\n    at CommentPostedToVideo.get comentId [as comentId] (/orion/lib/model/generated/_commentPostedToVideo.js:77:30)\n    at CommentPostedToVideo.toJSON (/orion/lib/model/generated/_commentPostedToVideo.js:89:28)\n    at Object.to (/orion/lib/model/generated/notification.model.js:38:68)\n    at Function.transformTo (/orion/node_modules/typeorm/util/ApplyValueTransformers.js:20:28)\n    at PostgresDriver.preparePersistentValue (/orion/node_modules/typeorm/driver/postgres/PostgresDriver.js:405:69)\n    at /orion/node_modules/typeorm/query-builder/InsertQueryBuilder.js:487:56\n    at Array.forEach (<anonymous>)\n    at /orion/node_modules/typeorm/query-builder/InsertQueryBuilder.js:463:25\n    at Array.forEach (<anonymous>)\n    at InsertQueryBuilder.createValuesExpression (/orion/node_modules/typeorm/query-builder/InsertQueryBuilder.js:462:23)"}}
```
and adds a test