### PR TITLE
Remove n+1 problem for StorageDataObject

### DIFF
--- a/src/server-extension/resolvers/AssetsResolver/index.ts
+++ b/src/server-extension/resolvers/AssetsResolver/index.ts
@@ -1,7 +1,6 @@
 import { FieldResolver, Root, ObjectType, Field, Resolver, Ctx } from 'type-graphql'
 import { EntityManager } from 'typeorm'
 import {
-  StorageDataObject as DataObjectEntity,
   DistributionBucket,
   DistributionBucketOperatorMetadata,
   DistributionBucketOperatorStatus,
@@ -227,9 +226,18 @@ function getResolvedUrlsLimit(ctx: Context): number {
 }
 
 @ObjectType()
+class StorageBag {
+  @Field()
+  id!: string
+}
+
+@ObjectType()
 export class StorageDataObject {
   @Field()
   id!: string
+
+  @Field()
+  storageBag: StorageBag
 
   @Field(() => [String])
   resolvedUrls: string[]
@@ -242,20 +250,14 @@ export class AssetsResolver {
 
   @FieldResolver(() => [String])
   async resolvedUrls(@Root() object: StorageDataObject, @Ctx() ctx: Context): Promise<string[]> {
-    const em = await this.em()
     const clientLoc = await getClientLoc(ctx)
     const limit = await getResolvedUrlsLimit(ctx)
     // The resolvedUrl field is initially populated with the object ID
     const [objectId] = object.resolvedUrls
-    if (!objectId) {
+    if (!object.storageBag || !objectId) {
       return []
     }
-    const { storageBagId } =
-      (await em.getRepository(DataObjectEntity).findOneBy({ id: objectId })) || {}
-    if (!storageBagId) {
-      return []
-    }
-    const buckets = await distributionBucketsCache.getBucketsByBagId(storageBagId)
+    const buckets = await distributionBucketsCache.getBucketsByBagId(object.storageBag.id)
     const nodes = buckets.flatMap((b) => b.nodes)
     if (clientLoc) {
       sortNodesByClosest(nodes, clientLoc)


### PR DESCRIPTION
## Problem 

Because `resolvedUrls` field is dynamically resolved it introduced the need for one extra query to the database for each video that is being queried. For example, if we try to fetch 100 videos, we would make one query to fetch all videos and fields that we need, but (assuming that we are fetching only `media` field with `resolvedUrls`) each video needed to query a DB for `StorageDataObject` to retrieve `storageBagId` and based on this create `resolvedUrls` array. 

If my logic is correct this problem is getting bigger went we start fetching data for Atlas, since Atlas will need 3 `StorageDataObjects` for a single video (media, thumbnail, asset fields in schema). So the problem grows from `n + 1` to `3n + 1`.

## Proposal

Field resolver for `resolvedUrls` gets the whole object that is fetched by graphql query, currently, the problem is that one can try to fetch only `resolvedUrls` on `DataStorageObject`, then the resolver needs to grab extra data from DB to correctly resolve this field. The thing is that we don't utilize the possibility that if the query is built in such a way that `storageBagId` is included, we can skip the one extra DB query for each asset.

But what to do when `storageBagId` is not included?
- throw an error and tell the user that it needs to be added to the query for `resolvedUrls` to work
- return empty array
- try to query it manually and resolve it as we do now