### PR TITLE
Patch connection query builder

### DIFF
--- a/assets/patches/@subsquid+openreader+3.1.7.patch
+++ b/assets/patches/@subsquid+openreader+3.1.7.patch
@@ -93,3 +93,52 @@ index 6fb0711..89e3d3d 100644
      });
      return (0, util_internal_http_server_1.listen)(server, options.port);
  }
+diff --git a/node_modules/@subsquid/openreader/lib/sql/query.d.ts.map b/node_modules/@subsquid/openreader/lib/sql/query.d.ts.map
+index 7f7c281..ad39c31 100644
+--- a/node_modules/@subsquid/openreader/lib/sql/query.d.ts.map
++++ b/node_modules/@subsquid/openreader/lib/sql/query.d.ts.map
+@@ -1 +1 @@
+-{"version":3,"file":"query.d.ts","sourceRoot":"","sources":["../../src/sql/query.ts"],"names":[],"mappings":"AAEA,OAAO,KAAK,EAAC,OAAO,EAAC,MAAM,YAAY,CAAA;AACvC,OAAO,KAAK,EAAC,YAAY,EAAE,KAAK,EAAC,MAAM,YAAY,CAAA;AACnD,OAAO,EAKH,sBAAsB,EACtB,uBAAuB,EAC1B,MAAM,kBAAkB,CAAA;AACzB,OAAO,KAAK,EAAC,SAAS,EAAE,YAAY,EAAC,MAAM,cAAc,CAAA;AACzD,OAAO,KAAK,EAAC,KAAK,EAAC,MAAM,UAAU,CAAA;AAMnC,MAAM,WAAW,KAAK,CAAC,CAAC;IACpB,QAAQ,CAAC,GAAG,EAAE,MAAM,CAAA;IACpB,QAAQ,CAAC,MAAM,EAAE,OAAO,EAAE,CAAA;IAC1B,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,EAAE,GAAG,CAAC,CAAA;CACxB;AAGD,qBAAa,SAAU,YAAW,KAAK,CAAC,GAAG,EAAE,CAAC;IAQtC,OAAO,CAAC,MAAM;IAPlB,SAAgB,GAAG,EAAE,MAAM,CAAA;IAC3B,SAAgB,MAAM,EAAE,OAAO,EAAE,CAAK;gBAGlC,KAAK,EAAE,KAAK,EACZ,OAAO,EAAE,OAAO,EAChB,QAAQ,EAAE,MAAM,EACR,MAAM,EAAE,SAAS,EACzB,IAAI,EAAE,YAAY;IAWtB,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,EAAE,GAAG,GAAG,EAAE;CAO5B;AAGD,qBAAa,eAAe;IAQpB,OAAO,CAAC,MAAM;IAPlB,SAAgB,GAAG,EAAE,MAAM,CAAA;IAC3B,SAAgB,MAAM,EAAE,OAAO,EAAE,CAAK;gBAGlC,KAAK,EAAE,KAAK,EACZ,OAAO,EAAE,OAAO,EAChB,UAAU,EAAE,MAAM,EACV,MAAM,EAAE,YAAY,EAAE,EAC9B,EAAE,EAAE,MAAM;IAYd,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,EAAE,GAAG,GAAG;CAI1B;AAGD,qBAAa,UAAW,YAAW,KAAK,CAAC,MAAM,CAAC;IAC5C,SAAgB,GAAG,EAAE,MAAM,CAAA;IAC3B,SAAgB,MAAM,EAAE,OAAO,EAAE,CAAK;gBAGlC,KAAK,EAAE,KAAK,EACZ,OAAO,EAAE,OAAO,EAChB,QAAQ,EAAE,MAAM,EAChB,KAAK,CAAC,EAAE,KAAK;IAMjB,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,EAAE,GAAG,MAAM;CAG7B;AAGD,qBAAa,eAAgB,YAAW,KAAK,CAAC,uBAAuB,CAAC;IAClE,SAAgB,GAAG,EAAE,MAAM,CAAA;IAC3B,SAAgB,MAAM,EAAE,OAAO,EAAE,CAAK;IACtC,OAAO,CAAC,MAAM,CAAI;IAClB,OAAO,CAAC,KAAK,CAAM;IACnB,OAAO,CAAC,QAAQ,CAAC,CAAW;IAC5B,OAAO,CAAC,UAAU,CAAC,CAAS;IAC5B,OAAO,CAAC,QAAQ,CAAC,CAAS;IAC1B,OAAO,CAAC,UAAU,CAAC,CAAS;gBAGxB,KAAK,EAAE,KAAK,EACZ,OAAO,EAAE,OAAO,EAChB,QAAQ,EAAE,MAAM,EAChB,GAAG,EAAE,sBAAsB,CAAC,SAAS,CAAC;IA+B1C,OAAO,CAAC,iBAAiB;IAUzB,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,EAAE,GAAG,uBAAuB;IA8B3C,OAAO,CAAC,WAAW;IAUnB,OAAO,CAAC,aAAa;CAQxB"}
+\ No newline at end of file
++{"version":3,"file":"query.d.ts","sourceRoot":"","sources":["../../src/sql/query.ts"],"names":[],"mappings":"AAEA,OAAO,KAAK,EAAC,OAAO,EAAC,MAAM,YAAY,CAAA;AACvC,OAAO,KAAK,EAAC,YAAY,EAAE,KAAK,EAAC,MAAM,YAAY,CAAA;AACnD,OAAO,EAKH,sBAAsB,EACtB,uBAAuB,EAC1B,MAAM,kBAAkB,CAAA;AACzB,OAAO,KAAK,EAAC,SAAS,EAAE,YAAY,EAAC,MAAM,cAAc,CAAA;AACzD,OAAO,KAAK,EAAC,KAAK,EAAC,MAAM,UAAU,CAAA;AAMnC,MAAM,WAAW,KAAK,CAAC,CAAC;IACpB,QAAQ,CAAC,GAAG,EAAE,MAAM,CAAA;IACpB,QAAQ,CAAC,MAAM,EAAE,OAAO,EAAE,CAAA;IAC1B,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,EAAE,GAAG,CAAC,CAAA;CACxB;AAGD,qBAAa,SAAU,YAAW,KAAK,CAAC,GAAG,EAAE,CAAC;IAQtC,OAAO,CAAC,MAAM;IAPlB,SAAgB,GAAG,EAAE,MAAM,CAAA;IAC3B,SAAgB,MAAM,EAAE,OAAO,EAAE,CAAK;gBAGlC,KAAK,EAAE,KAAK,EACZ,OAAO,EAAE,OAAO,EAChB,QAAQ,EAAE,MAAM,EACR,MAAM,EAAE,SAAS,EACzB,IAAI,EAAE,YAAY;IAWtB,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,EAAE,GAAG,GAAG,EAAE;CAO5B;AAGD,qBAAa,eAAe;IAQpB,OAAO,CAAC,MAAM;IAPlB,SAAgB,GAAG,EAAE,MAAM,CAAA;IAC3B,SAAgB,MAAM,EAAE,OAAO,EAAE,CAAK;gBAGlC,KAAK,EAAE,KAAK,EACZ,OAAO,EAAE,OAAO,EAChB,UAAU,EAAE,MAAM,EACV,MAAM,EAAE,YAAY,EAAE,EAC9B,EAAE,EAAE,MAAM;IAYd,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,EAAE,GAAG,GAAG;CAI1B;AAGD,qBAAa,UAAW,YAAW,KAAK,CAAC,MAAM,CAAC;IAC5C,SAAgB,GAAG,EAAE,MAAM,CAAA;IAC3B,SAAgB,MAAM,EAAE,OAAO,EAAE,CAAK;gBAGlC,KAAK,EAAE,KAAK,EACZ,OAAO,EAAE,OAAO,EAChB,QAAQ,EAAE,MAAM,EAChB,KAAK,CAAC,EAAE,KAAK;IAMjB,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,EAAE,GAAG,MAAM;CAG7B;AAGD,qBAAa,eAAgB,YAAW,KAAK,CAAC,uBAAuB,CAAC;IAClE,SAAgB,GAAG,EAAE,MAAM,CAAA;IAC3B,SAAgB,MAAM,EAAE,OAAO,EAAE,CAAK;IACtC,OAAO,CAAC,MAAM,CAAI;IAClB,OAAO,CAAC,KAAK,CAAM;IACnB,OAAO,CAAC,QAAQ,CAAC,CAAW;IAC5B,OAAO,CAAC,UAAU,CAAC,CAAS;IAC5B,OAAO,CAAC,QAAQ,CAAC,CAAS;IAC1B,OAAO,CAAC,UAAU,CAAC,CAAS;gBAGxB,KAAK,EAAE,KAAK,EACZ,OAAO,EAAE,OAAO,EAChB,QAAQ,EAAE,MAAM,EAChB,GAAG,EAAE,sBAAsB,CAAC,SAAS,CAAC;IA8C1C,OAAO,CAAC,iBAAiB;IAUzB,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,EAAE,GAAG,uBAAuB;IA8B3C,OAAO,CAAC,WAAW;IAUnB,OAAO,CAAC,aAAa;CAQxB"}
+\ No newline at end of file
+diff --git a/node_modules/@subsquid/openreader/lib/sql/query.js b/node_modules/@subsquid/openreader/lib/sql/query.js
+index c00a15f..014b776 100644
+--- a/node_modules/@subsquid/openreader/lib/sql/query.js
++++ b/node_modules/@subsquid/openreader/lib/sql/query.js
+@@ -72,9 +72,18 @@ class ConnectionQuery {
+             limit: this.limit + 1
+         };
+         let printer;
++        let wherePrinter;
+         if (model[typeName].kind == 'entity') {
+             (0, assert_1.default)(req.edgeNode == null || Array.isArray(req.edgeNode));
+-            printer = new printer_1.EntitySqlPrinter(model, dialect, typeName, this.params, args, req.edgeNode);
++            const idField = req.edgeNode?.find(eN => eN.field === 'id');
++            if (idField) {
++                wherePrinter = new printer_1.EntitySqlPrinter(model, dialect, typeName, this.params, {
++                    where: args.where,
++                    offset: args.offset,
++                    limit: args.limit
++                }, [idField]);
++            }
++            printer = new printer_1.EntitySqlPrinter(model, dialect, typeName, this.params, idField ? { orderBy: req.orderBy } : args, req.edgeNode);
+         }
+         else {
+             (0, assert_1.default)(req.edgeNode == null || !Array.isArray(req.edgeNode));
+@@ -82,7 +91,14 @@ class ConnectionQuery {
+         }
+         if (req.edgeNode) {
+             this.edgeNode = req.edgeNode;
+-            this.sql = printer.print();
++            if (wherePrinter) {
++                const mainPrinter = printer.print().split('ORDER BY');
++                mainPrinter[0] = `${mainPrinter[0]} WHERE "${(0, util_1.toTable)(typeName)}"."id" IN (${wherePrinter.print()})`;
++                this.sql = mainPrinter.join(' ORDER BY');
++            }
++            else {
++                this.sql = printer.print();
++            }
+         }
+         else {
+             this.sql = printer.printAsCount();

--- a/assets/patches/@subsquid+openreader+3.1.7.patch
+++ b/assets/patches/@subsquid+openreader+3.1.7.patch
@@ -103,10 +103,10 @@ index 7f7c281..ad39c31 100644
 +{"version":3,"file":"query.d.ts","sourceRoot":"","sources":["../../src/sql/query.ts"],"names":[],"mappings":"AAEA,OAAO,KAAK,EAAC,OAAO,EAAC,MAAM,YAAY,CAAA;AACvC,OAAO,KAAK,EAAC,YAAY,EAAE,KAAK,EAAC,MAAM,YAAY,CAAA;AACnD,OAAO,EAKH,sBAAsB,EACtB,uBAAuB,EAC1B,MAAM,kBAAkB,CAAA;AACzB,OAAO,KAAK,EAAC,SAAS,EAAE,YAAY,EAAC,MAAM,cAAc,CAAA;AACzD,OAAO,KAAK,EAAC,KAAK,EAAC,MAAM,UAAU,CAAA;AAMnC,MAAM,WAAW,KAAK,CAAC,CAAC;IACpB,QAAQ,CAAC,GAAG,EAAE,MAAM,CAAA;IACpB,QAAQ,CAAC,MAAM,EAAE,OAAO,EAAE,CAAA;IAC1B,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,EAAE,GAAG,CAAC,CAAA;CACxB;AAGD,qBAAa,SAAU,YAAW,KAAK,CAAC,GAAG,EAAE,CAAC;IAQtC,OAAO,CAAC,MAAM;IAPlB,SAAgB,GAAG,EAAE,MAAM,CAAA;IAC3B,SAAgB,MAAM,EAAE,OAAO,EAAE,CAAK;gBAGlC,KAAK,EAAE,KAAK,EACZ,OAAO,EAAE,OAAO,EAChB,QAAQ,EAAE,MAAM,EACR,MAAM,EAAE,SAAS,EACzB,IAAI,EAAE,YAAY;IAWtB,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,EAAE,GAAG,GAAG,EAAE;CAO5B;AAGD,qBAAa,eAAe;IAQpB,OAAO,CAAC,MAAM;IAPlB,SAAgB,GAAG,EAAE,MAAM,CAAA;IAC3B,SAAgB,MAAM,EAAE,OAAO,EAAE,CAAK;gBAGlC,KAAK,EAAE,KAAK,EACZ,OAAO,EAAE,OAAO,EAChB,UAAU,EAAE,MAAM,EACV,MAAM,EAAE,YAAY,EAAE,EAC9B,EAAE,EAAE,MAAM;IAYd,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,EAAE,GAAG,GAAG;CAI1B;AAGD,qBAAa,UAAW,YAAW,KAAK,CAAC,MAAM,CAAC;IAC5C,SAAgB,GAAG,EAAE,MAAM,CAAA;IAC3B,SAAgB,MAAM,EAAE,OAAO,EAAE,CAAK;gBAGlC,KAAK,EAAE,KAAK,EACZ,OAAO,EAAE,OAAO,EAChB,QAAQ,EAAE,MAAM,EAChB,KAAK,CAAC,EAAE,KAAK;IAMjB,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,EAAE,GAAG,MAAM;CAG7B;AAGD,qBAAa,eAAgB,YAAW,KAAK,CAAC,uBAAuB,CAAC;IAClE,SAAgB,GAAG,EAAE,MAAM,CAAA;IAC3B,SAAgB,MAAM,EAAE,OAAO,EAAE,CAAK;IACtC,OAAO,CAAC,MAAM,CAAI;IAClB,OAAO,CAAC,KAAK,CAAM;IACnB,OAAO,CAAC,QAAQ,CAAC,CAAW;IAC5B,OAAO,CAAC,UAAU,CAAC,CAAS;IAC5B,OAAO,CAAC,QAAQ,CAAC,CAAS;IAC1B,OAAO,CAAC,UAAU,CAAC,CAAS;gBAGxB,KAAK,EAAE,KAAK,EACZ,OAAO,EAAE,OAAO,EAChB,QAAQ,EAAE,MAAM,EAChB,GAAG,EAAE,sBAAsB,CAAC,SAAS,CAAC;IA8C1C,OAAO,CAAC,iBAAiB;IAUzB,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,EAAE,GAAG,uBAAuB;IA8B3C,OAAO,CAAC,WAAW;IAUnB,OAAO,CAAC,aAAa;CAQxB"}
 \ No newline at end of file
 diff --git a/node_modules/@subsquid/openreader/lib/sql/query.js b/node_modules/@subsquid/openreader/lib/sql/query.js
-index c00a15f..014b776 100644
+index c00a15f..bef62c0 100644
 --- a/node_modules/@subsquid/openreader/lib/sql/query.js
 +++ b/node_modules/@subsquid/openreader/lib/sql/query.js
-@@ -72,9 +72,18 @@ class ConnectionQuery {
+@@ -72,9 +72,14 @@ class ConnectionQuery {
              limit: this.limit + 1
          };
          let printer;
@@ -116,17 +116,13 @@ index c00a15f..014b776 100644
 -            printer = new printer_1.EntitySqlPrinter(model, dialect, typeName, this.params, args, req.edgeNode);
 +            const idField = req.edgeNode?.find(eN => eN.field === 'id');
 +            if (idField) {
-+                wherePrinter = new printer_1.EntitySqlPrinter(model, dialect, typeName, this.params, {
-+                    where: args.where,
-+                    offset: args.offset,
-+                    limit: args.limit
-+                }, [idField]);
++                wherePrinter = new printer_1.EntitySqlPrinter(model, dialect, typeName, this.params, args, [idField]);
 +            }
 +            printer = new printer_1.EntitySqlPrinter(model, dialect, typeName, this.params, idField ? { orderBy: req.orderBy } : args, req.edgeNode);
          }
          else {
              (0, assert_1.default)(req.edgeNode == null || !Array.isArray(req.edgeNode));
-@@ -82,7 +91,14 @@ class ConnectionQuery {
+@@ -82,7 +87,14 @@ class ConnectionQuery {
          }
          if (req.edgeNode) {
              this.edgeNode = req.edgeNode;

--- a/assets/patches/@subsquid+openreader+3.1.7.patch
+++ b/assets/patches/@subsquid+openreader+3.1.7.patch
@@ -103,7 +103,7 @@ index 7f7c281..ad39c31 100644
 +{"version":3,"file":"query.d.ts","sourceRoot":"","sources":["../../src/sql/query.ts"],"names":[],"mappings":"AAEA,OAAO,KAAK,EAAC,OAAO,EAAC,MAAM,YAAY,CAAA;AACvC,OAAO,KAAK,EAAC,YAAY,EAAE,KAAK,EAAC,MAAM,YAAY,CAAA;AACnD,OAAO,EAKH,sBAAsB,EACtB,uBAAuB,EAC1B,MAAM,kBAAkB,CAAA;AACzB,OAAO,KAAK,EAAC,SAAS,EAAE,YAAY,EAAC,MAAM,cAAc,CAAA;AACzD,OAAO,KAAK,EAAC,KAAK,EAAC,MAAM,UAAU,CAAA;AAMnC,MAAM,WAAW,KAAK,CAAC,CAAC;IACpB,QAAQ,CAAC,GAAG,EAAE,MAAM,CAAA;IACpB,QAAQ,CAAC,MAAM,EAAE,OAAO,EAAE,CAAA;IAC1B,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,EAAE,GAAG,CAAC,CAAA;CACxB;AAGD,qBAAa,SAAU,YAAW,KAAK,CAAC,GAAG,EAAE,CAAC;IAQtC,OAAO,CAAC,MAAM;IAPlB,SAAgB,GAAG,EAAE,MAAM,CAAA;IAC3B,SAAgB,MAAM,EAAE,OAAO,EAAE,CAAK;gBAGlC,KAAK,EAAE,KAAK,EACZ,OAAO,EAAE,OAAO,EAChB,QAAQ,EAAE,MAAM,EACR,MAAM,EAAE,SAAS,EACzB,IAAI,EAAE,YAAY;IAWtB,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,EAAE,GAAG,GAAG,EAAE;CAO5B;AAGD,qBAAa,eAAe;IAQpB,OAAO,CAAC,MAAM;IAPlB,SAAgB,GAAG,EAAE,MAAM,CAAA;IAC3B,SAAgB,MAAM,EAAE,OAAO,EAAE,CAAK;gBAGlC,KAAK,EAAE,KAAK,EACZ,OAAO,EAAE,OAAO,EAChB,UAAU,EAAE,MAAM,EACV,MAAM,EAAE,YAAY,EAAE,EAC9B,EAAE,EAAE,MAAM;IAYd,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,EAAE,GAAG,GAAG;CAI1B;AAGD,qBAAa,UAAW,YAAW,KAAK,CAAC,MAAM,CAAC;IAC5C,SAAgB,GAAG,EAAE,MAAM,CAAA;IAC3B,SAAgB,MAAM,EAAE,OAAO,EAAE,CAAK;gBAGlC,KAAK,EAAE,KAAK,EACZ,OAAO,EAAE,OAAO,EAChB,QAAQ,EAAE,MAAM,EAChB,KAAK,CAAC,EAAE,KAAK;IAMjB,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,EAAE,GAAG,MAAM;CAG7B;AAGD,qBAAa,eAAgB,YAAW,KAAK,CAAC,uBAAuB,CAAC;IAClE,SAAgB,GAAG,EAAE,MAAM,CAAA;IAC3B,SAAgB,MAAM,EAAE,OAAO,EAAE,CAAK;IACtC,OAAO,CAAC,MAAM,CAAI;IAClB,OAAO,CAAC,KAAK,CAAM;IACnB,OAAO,CAAC,QAAQ,CAAC,CAAW;IAC5B,OAAO,CAAC,UAAU,CAAC,CAAS;IAC5B,OAAO,CAAC,QAAQ,CAAC,CAAS;IAC1B,OAAO,CAAC,UAAU,CAAC,CAAS;gBAGxB,KAAK,EAAE,KAAK,EACZ,OAAO,EAAE,OAAO,EAChB,QAAQ,EAAE,MAAM,EAChB,GAAG,EAAE,sBAAsB,CAAC,SAAS,CAAC;IA8C1C,OAAO,CAAC,iBAAiB;IAUzB,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,EAAE,GAAG,uBAAuB;IA8B3C,OAAO,CAAC,WAAW;IAUnB,OAAO,CAAC,aAAa;CAQxB"}
 \ No newline at end of file
 diff --git a/node_modules/@subsquid/openreader/lib/sql/query.js b/node_modules/@subsquid/openreader/lib/sql/query.js
-index c00a15f..bef62c0 100644
+index c00a15f..2623b28 100644
 --- a/node_modules/@subsquid/openreader/lib/sql/query.js
 +++ b/node_modules/@subsquid/openreader/lib/sql/query.js
 @@ -72,9 +72,14 @@ class ConnectionQuery {
@@ -118,19 +118,17 @@ index c00a15f..bef62c0 100644
 +            if (idField) {
 +                wherePrinter = new printer_1.EntitySqlPrinter(model, dialect, typeName, this.params, args, [idField]);
 +            }
-+            printer = new printer_1.EntitySqlPrinter(model, dialect, typeName, this.params, idField ? { orderBy: req.orderBy } : args, req.edgeNode);
++            printer = new printer_1.EntitySqlPrinter(model, dialect, typeName, this.params, idField ? {} : args, req.edgeNode);
          }
          else {
              (0, assert_1.default)(req.edgeNode == null || !Array.isArray(req.edgeNode));
-@@ -82,7 +87,14 @@ class ConnectionQuery {
+@@ -82,7 +87,12 @@ class ConnectionQuery {
          }
          if (req.edgeNode) {
              this.edgeNode = req.edgeNode;
 -            this.sql = printer.print();
 +            if (wherePrinter) {
-+                const mainPrinter = printer.print().split('ORDER BY');
-+                mainPrinter[0] = `${mainPrinter[0]} WHERE "${(0, util_1.toTable)(typeName)}"."id" IN (${wherePrinter.print()})`;
-+                this.sql = mainPrinter.join(' ORDER BY');
++                this.sql = `WITH id_list AS (${wherePrinter.print()}) ${printer.print()} JOIN id_list ON "${(0, util_1.toTable)(typeName)}"."id" = id_list._c0;`;
 +            }
 +            else {
 +                this.sql = printer.print();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orion",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "orion",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "hasInstallScript": true,
       "dependencies": {
         "@joystream/js": "^1.4.0",


### PR DESCRIPTION
## Context

Making normal queries with ORDER BY, LIMIT and OFFSET will take more time as the offset grows. The easy way to mitigate this is to get the required fields after WHERE, ORDER, LIMIT and OFFSET is already calculated, but just of the IDs of the table.

## Proposals 

The first solution I found is to base the whole query on WHERE id IN (SELECT id from x WHERE ... ORDER BY ... etc.) clause, which will quickly return us the ids of needed rows and get all the JOINS and their own data by ID, which is quicker.

This solution is in this commit: https://github.com/WRadoslaw/squid-sdk/pull/1/commits/f45bbce730b8392d80fdc7fab6a145688cfeb0e8

The second solution seems to be faster since we don't have to do the ordering two times. In the first solution, it is there because an order from WHERE IN doesn't have to be the same as the result order.  The problem with this solution is that I'm not sure how robust it is since we have to reference CTE id column as `_c0`. 

2nd: https://github.com/WRadoslaw/squid-sdk/pull/1/commits/9a4f7650d4b434cf213a5325f7a394a392308034