### PR TITLE
Fix sub url paths not working when serving atlas using caddy

### DIFF
--- a/docs/operator-guide/examples/Caddyfile
+++ b/docs/operator-guide/examples/Caddyfile
@@ -13,5 +13,6 @@ archive.{$GATEWAY_ROOT_DOMAIN} {
 # # Optional: uncomment to serve atlas statically on the server
 # {$GATEWAY_ROOT_DOMAIN} {
 #     root * /srv/atlas
+#     try_files {path} /index.html
 #     file_server
 # }


### PR DESCRIPTION
Urls like `/marketplace` and `/discover` were returning 404