### PR TITLE
🤑 Fix revenue share dividend estimation

### DIFF
--- a/src/server-extension/resolvers/CreatorToken/index.ts
+++ b/src/server-extension/resolvers/CreatorToken/index.ts
@@ -35,7 +35,7 @@ export class TokenResolver {
     }
     const { allocation } = revenueShare
 
-    const dividendJoyAmount = (BigInt(stakingAmount) / totalSupply) * allocation
+    const dividendJoyAmount = (BigInt(stakingAmount) * allocation) / totalSupply
     return {
       dividendJoyAmount: Number(dividendJoyAmount),
     }

--- a/src/server-extension/resolvers/CreatorToken/index.ts
+++ b/src/server-extension/resolvers/CreatorToken/index.ts
@@ -37,7 +37,7 @@ export class TokenResolver {
 
     const dividendJoyAmount = (BigInt(stakingAmount) * allocation) / totalSupply
     return {
-      dividendJoyAmount: Number(dividendJoyAmount),
+      dividendJoyAmount: dividendJoyAmount.toString(),
     }
   }
 

--- a/src/server-extension/resolvers/CreatorToken/types.ts
+++ b/src/server-extension/resolvers/CreatorToken/types.ts
@@ -11,8 +11,8 @@ export class GetShareDividensArgs {
 
 @ObjectType()
 export class GetShareDividendsResult {
-  @Field(() => Number, { nullable: false })
-  dividendJoyAmount!: number
+  @Field(() => String, { nullable: false })
+  dividendJoyAmount!: string
 }
 
 @ArgsType()


### PR DESCRIPTION
Issue: if we first divide the staking amount by the total supply BigNumber will floor the result to 0 since it doesn't support decimal places

