### PR TITLE
Disable both in App and email notifications for video posted events

### DIFF
--- a/src/utils/notification/helpers.ts
+++ b/src/utils/notification/helpers.ts
@@ -23,6 +23,10 @@ function notificationPrefAllTrue(): NotificationPreference {
   return new NotificationPreference({ inAppEnabled: true, emailEnabled: true })
 }
 
+function notificationPrefAllFalse(): NotificationPreference {
+  return new NotificationPreference({ inAppEnabled: false, emailEnabled: false })
+}
+
 export function defaultNotificationPreferences(): AccountNotificationPreferences {
   return new AccountNotificationPreferences({
     channelExcludedFromApp: notificationPrefAllTrue(),
@@ -47,7 +51,7 @@ export function defaultNotificationPreferences(): AccountNotificationPreferences
     channelCreated: notificationPrefAllTrue(),
     replyToComment: notificationPrefAllTrue(),
     reactionToComment: notificationPrefAllTrue(),
-    videoPosted: notificationPrefAllTrue(),
+    videoPosted: notificationPrefAllFalse(),
     newNftOnAuction: notificationPrefAllTrue(),
     newNftOnSale: notificationPrefAllTrue(),
     higherBidThanYoursMade: notificationPrefAllTrue(),


### PR DESCRIPTION
SSIA.

TODO:
- [ ] Create a custom migration to apply this change (i.e. by default disabling notifications when a followed channel posts a new video) to all of the existing users too.