### PR TITLE
fix: CRT notifications bug

### DIFF
--- a/src/mappings/token/index.ts
+++ b/src/mappings/token/index.ts
@@ -246,7 +246,7 @@ export async function processAmmActivatedEvent({
     channelTitle: parseChannelTitle(channel),
   })
 
-  await notifyTokenHolders(overlay.getEm(), tokenId.toString(), notificationData, eventEntity)
+  await notifyTokenHolders(overlay, tokenId.toString(), notificationData, eventEntity)
   await notifyChannelFollowers(overlay, channel.id, notificationData, eventEntity)
 }
 
@@ -330,7 +330,7 @@ export async function processTokenSaleInitializedEvent({
     channelTitle: parseChannelTitle(channel),
   })
 
-  await notifyTokenHolders(overlay.getEm(), tokenId.toString(), notificationData, eventEntity)
+  await notifyTokenHolders(overlay, tokenId.toString(), notificationData, eventEntity)
   await notifyChannelFollowers(overlay, channel.id, notificationData, eventEntity)
 }
 
@@ -640,7 +640,7 @@ export async function processRevenueSplitIssuedEvent({
     tokenSymbol: parseCreatorTokenSymbol(token),
   })
   await notifyTokenHolders(
-    overlay.getEm(),
+    overlay,
     tokenId.toString(),
     revenueShareStartedNotification,
     undefined,
@@ -657,7 +657,7 @@ export async function processRevenueSplitIssuedEvent({
       tokenSymbol: parseCreatorTokenSymbol(token),
     })
 
-    await notifyTokenHolders(overlay.getEm(), tokenId.toString(), revenueSharePlannedNotification)
+    await notifyTokenHolders(overlay, tokenId.toString(), revenueSharePlannedNotification)
   }
 
   const revenueSharedEndedNotification = new CreatorTokenRevenueShareEnded({
@@ -668,7 +668,7 @@ export async function processRevenueSplitIssuedEvent({
     tokenId: tokenId.toString(),
   })
   await notifyTokenHolders(
-    overlay.getEm(),
+    overlay,
     tokenId.toString(),
     revenueSharedEndedNotification,
     undefined,

--- a/src/mappings/token/utils.ts
+++ b/src/mappings/token/utils.ts
@@ -2,7 +2,6 @@ import { ITokenMetadata } from '@joystream/metadata-protobuf'
 import { DecodedMetadataObject } from '@joystream/metadata-protobuf/types'
 import { isSet } from '@joystream/metadata-protobuf/utils'
 import pLimit from 'p-limit'
-import { EntityManager } from 'typeorm'
 import {
   Account,
   Benefit,
@@ -321,9 +320,10 @@ export async function processTokenMetadata(
 }
 
 export async function getHolderAccountsForToken(
-  em: EntityManager,
+  overlay: EntityManagerOverlay,
   tokenId: string
 ): Promise<Account[]> {
+  const em = overlay.getEm()
   const holders = await em.getRepository(TokenAccount).findBy({ tokenId })
 
   const holdersMemberIds = holders
@@ -341,7 +341,7 @@ export async function getHolderAccountsForToken(
 }
 
 export async function notifyTokenHolders(
-  em: EntityManager,
+  em: EntityManagerOverlay,
   tokenId: string,
   notificationType: NotificationType,
   event?: Event,


### PR DESCRIPTION
Pass `overlay` instance instead of the `entityManager` instance to CRT notification handlers.