### PR TITLE
fix: pass event entity arg to `notifyTokenHolders` function in `ProjectToken.RevenueSplitIssued`

### DIFF
--- a/src/mappings/token/index.ts
+++ b/src/mappings/token/index.ts
@@ -625,7 +625,7 @@ export async function processRevenueSplitIssuedEvent({
 
   token.currentRevenueShareId = id
 
-  overlay.getRepository(Event).new({
+  const event = overlay.getRepository(Event).new({
     ...genericEventFields(overlay, block, indexInBlock, extrinsicHash),
     data: new CreatorTokenRevenueSplitIssuedEventData({
       token: tokenId.toString(),
@@ -646,7 +646,7 @@ export async function processRevenueSplitIssuedEvent({
     overlay,
     tokenId.toString(),
     revenueShareStartedNotification,
-    undefined,
+    event,
     startBlock // schedule for start block
   )
 
@@ -660,7 +660,7 @@ export async function processRevenueSplitIssuedEvent({
       tokenSymbol: parseCreatorTokenSymbol(token),
     })
 
-    await notifyTokenHolders(overlay, tokenId.toString(), revenueSharePlannedNotification)
+    await notifyTokenHolders(overlay, tokenId.toString(), revenueSharePlannedNotification, event)
   }
 
   const revenueSharedEndedNotification = new CreatorTokenRevenueShareEnded({
@@ -674,7 +674,7 @@ export async function processRevenueSplitIssuedEvent({
     overlay,
     tokenId.toString(),
     revenueSharedEndedNotification,
-    undefined,
+    event,
     endsAt // schedule for end block
   )
 }


### PR DESCRIPTION
## Problem 

```
{"level":5,"time":1711375967343,"ns":"sqd:processor","err":{"stack":"TypeError: em.getRepository(...).findOne is not a function\n    at getNextIdForEntity (/orion/lib/utils/nextEntityId.js:14:60)\n    at addOffChainNotification (/orion/lib/utils/notification/helpers.js:135:76)\n    at addNotification (/orion/lib/utils/notification/helpers.js:209:15)\n    at /orion/lib/mappings/token/utils.js:244:110\n    at /orion/node_modules/p-limit/index.js:23:31\n    at run (/orion/node_modules/p-limit/index.js:23:43)\n    at /orion/node_modules/p-limit/index.js:45:20\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)"}}
```

In the mappings `ProjectToken.RevenueSplitIssued` mappings we were not passing the event entity to the `notifyTokenHolders` function, because of that the notification was interpreted as offchain notification and hence using db store/connection as `EntityManager` instead of `EntityManagerOverlay`