### PR TITLE
Fix: `ProjectToken.RevenueSplitLeft` mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-# 4.0.0
+# 4.0.2
+
+## Bug Fixes:
+- Fixed: unstake tokens atfer revenue share has been finalized.
+- Fixed: transform raw json objects to `jsonb` properties while importing the offchain state.
+- Fixed: `bigint` to `number` conversion in `getCumulativeHistoricalShareAllocation` custom resolver.
+- Fixed duplicate notifications being received by users for featured NFTs.
+
+# 4.0.1
 
 ## Misc
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orion",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orion",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "hasInstallScript": true,
       "workspaces": [
         "network-tests"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orion",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "engines": {
     "node": ">=16"
   },

--- a/src/mappings/token/index.ts
+++ b/src/mappings/token/index.ts
@@ -768,7 +768,7 @@ export async function processRevenueSplitLeftEvent({
       await overlay
         .getRepository(RevenueShareParticipation)
         .getManyByRelation('accountId', account.id)
-    ).find((participation) => participation.revenueShareId === revenueShare.id)
+    ).find((participation) => participation.recovered === false)
     if (qRevenueShareParticipation) {
       qRevenueShareParticipation.recovered = true
     }

--- a/src/mappings/token/index.ts
+++ b/src/mappings/token/index.ts
@@ -766,12 +766,6 @@ export async function processRevenueSplitLeftEvent({
 
   if (revenueShareParticipation) {
     revenueShareParticipation.recovered = true
-
-    const revenueShare = await overlay
-      .getRepository(RevenueShare)
-      .getByIdOrFail(revenueShareParticipation.revenueShareId || '')
-
-    revenueShare.participantsNum -= 1
   }
 }
 

--- a/src/server-extension/resolvers/CreatorToken/index.ts
+++ b/src/server-extension/resolvers/CreatorToken/index.ts
@@ -57,7 +57,7 @@ export class TokenResolver {
       cumulativeAllocationAmount += share.allocation
     }
     return {
-      cumulativeHistoricalAllocation: Number(cumulativeAllocationAmount),
+      cumulativeHistoricalAllocation: cumulativeAllocationAmount.toString(),
     }
   }
 

--- a/src/server-extension/resolvers/CreatorToken/types.ts
+++ b/src/server-extension/resolvers/CreatorToken/types.ts
@@ -23,8 +23,8 @@ export class GetCumulativeHistoricalShareAllocationArgs {
 
 @ObjectType()
 export class GetCumulativeHistoricalShareAllocationResult {
-  @Field(() => Int, { nullable: false })
-  cumulativeHistoricalAllocation!: number
+  @Field(() => String, { nullable: false })
+  cumulativeHistoricalAllocation!: string
 }
 
 @ArgsType()


### PR DESCRIPTION

This fix makes it possible to unstake participant tokens after the current revenue share is finalized and the new revenue share is started