### PR TITLE
fix: update docker image for orion_archive_gateway container to fix `pool timed out while waiting for an open connection` error

### DIFF
--- a/archive/docker-compose.yml
+++ b/archive/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     depends_on:
       - archive_db
     restart: unless-stopped
-    image: subsquid/substrate-gateway:firesquid
+    image: zeeshanakram3/substrate-gateway:firesquid
     environment:
       DATABASE_MAX_CONNECTIONS: 5
       RUST_LOG: 'actix_web=info,actix_server=info'


### PR DESCRIPTION
Fixes `pool timed out while waiting for an open connection` error which occasionally crashes the Orion processor