### PR TITLE
fix: avoiding IDs override/conflict while creating concurrent runtime notifications

### DIFF
--- a/src/mappings/token/utils.ts
+++ b/src/mappings/token/utils.ts
@@ -327,8 +327,8 @@ export async function getHolderAccountsForToken(
   const holders = await em.getRepository(TokenAccount).findBy({ tokenId })
 
   const holdersMemberIds = holders
-    .filter((follower) => follower?.memberId)
-    .map((follower) => follower.memberId as string)
+    .filter((holder) => holder?.memberId)
+    .map((holder) => holder.memberId as string)
 
   const limit = pLimit(10) // Limit to 10 concurrent promises
   const holdersAccounts: (Account | null)[] = await Promise.all(
@@ -347,17 +347,17 @@ export async function notifyTokenHolders(
   event?: Event,
   dispatchBlock?: number
 ) {
-  const holdersAccounts = await getHolderAccountsForToken(em, tokenId)
+  const holderAccounts = await getHolderAccountsForToken(em, tokenId)
 
   const limit = pLimit(10) // Limit to 10 concurrent promises
 
   await Promise.all(
-    holdersAccounts.map((holdersAccount) =>
+    holderAccounts.map((holderAccount) =>
       limit(() =>
         addNotification(
           em,
-          holdersAccount,
-          new MemberRecipient({ membership: holdersAccount.membershipId }),
+          holderAccount,
+          new MemberRecipient({ membership: holderAccount.membershipId }),
           notificationType,
           event,
           dispatchBlock

--- a/src/utils/nextEntityId.ts
+++ b/src/utils/nextEntityId.ts
@@ -6,18 +6,22 @@ import { AnyEntity, Constructor, EntityManagerOverlay } from './overlay'
 export async function getNextIdForEntity(
   store: EntityManager | EntityManagerOverlay,
   entityName: string
-): Promise<string | undefined> {
+): Promise<number> {
   // Get next entity id from overlay (this will mostly be used in the mappings context)
   if (store instanceof EntityManagerOverlay) {
     const row = await store
       .getRepository(NextEntityId as Constructor<NextEntityId & AnyEntity>)
       .getOneBy({ entityName: entityName })
 
-    const id = row?.nextId.toString()
+    const id = parseInt(row?.nextId.toString() || '1')
 
     // Update the id to be the next one in the overlay
     if (row) {
       row.nextId++
+    } else {
+      store
+        .getRepository(NextEntityId as Constructor<NextEntityId & AnyEntity>)
+        .new({ entityName, nextId: id + 1 })
     }
 
     return id
@@ -35,6 +39,6 @@ export async function getNextIdForEntity(
       lock: { mode: 'pessimistic_write' },
     })
   }
-  const id = row?.nextId.toString()
+  const id = parseInt(row?.nextId.toString() || '1')
   return id
 }

--- a/src/utils/nextEntityId.ts
+++ b/src/utils/nextEntityId.ts
@@ -1,19 +1,40 @@
 import { EntityManager } from 'typeorm'
 import { NextEntityId } from '../model'
+import { AnyEntity, Constructor, EntityManagerOverlay } from './overlay'
 
-// used to retrieve the next id for an entity
-export async function getNextIdForEntity(em: EntityManager, entityName: string): Promise<number> {
+// used to retrieve the next id for an entity from NextEntityId table using either EntityManager or Overlay
+export async function getNextIdForEntity(
+  store: EntityManager | EntityManagerOverlay,
+  entityName: string
+): Promise<string | undefined> {
+  // Get next entity id from overlay (this will mostly be used in the mappings context)
+  if (store instanceof EntityManagerOverlay) {
+    const row = await store
+      .getRepository(NextEntityId as Constructor<NextEntityId & AnyEntity>)
+      .getOneBy({ entityName: entityName })
+
+    const id = row?.nextId.toString()
+
+    // Update the id to be the next one in the overlay
+    if (row) {
+      row.nextId++
+    }
+
+    return id
+  }
+
+  // Get next entity id from EntityManager (this will mostly be used in the graphql-server/auth-api context)
   let row: NextEntityId | null
   if (process.env.TESTING === 'true' || process.env.TESTING === '1') {
-    row = await em.getRepository(NextEntityId).findOne({
+    row = await store.getRepository(NextEntityId).findOne({
       where: { entityName },
     })
   } else {
-    row = await em.getRepository(NextEntityId).findOne({
+    row = await store.getRepository(NextEntityId).findOne({
       where: { entityName },
       lock: { mode: 'pessimistic_write' },
     })
   }
-  const id = parseInt(row?.nextId.toString() || '1')
+  const id = row?.nextId.toString()
   return id
 }

--- a/src/utils/notification/helpers.ts
+++ b/src/utils/notification/helpers.ts
@@ -13,7 +13,6 @@ import {
   Unread,
 } from '../../model'
 import { uniqueId } from '../crypto'
-import { criticalError } from '../misc'
 import { getNextIdForEntity } from '../nextEntityId'
 import { EntityManagerOverlay } from '../overlay'
 
@@ -157,7 +156,7 @@ async function addOffChainNotification(
   dispatchBlock?: number
 ) {
   // get notification Id from orion_db in any case
-  const nextNotificationId = (await getNextIdForEntity(em, OFFCHAIN_NOTIFICATION_ID_TAG)) || '1'
+  const nextNotificationId = await getNextIdForEntity(em, OFFCHAIN_NOTIFICATION_ID_TAG)
 
   const notification = createNotification(
     `${OFFCHAIN_NOTIFICATION_ID_TAG}-${nextNotificationId}`,
@@ -176,7 +175,7 @@ async function addOffChainNotification(
     await createEmailNotification(em, notification)
   }
 
-  await saveNextNotificationId(em, parseInt(nextNotificationId) + 1, OFFCHAIN_NOTIFICATION_ID_TAG)
+  await saveNextNotificationId(em, nextNotificationId + 1, OFFCHAIN_NOTIFICATION_ID_TAG)
 }
 
 async function addRuntimeNotification(
@@ -189,10 +188,6 @@ async function addRuntimeNotification(
 ) {
   // get notification Id from orion_db in any case
   const nextNotificationId = await getNextIdForEntity(overlay, RUNTIME_NOTIFICATION_ID_TAG)
-
-  if (!nextNotificationId) {
-    criticalError(`NextEntityId counter for "RuntimeNotification" tag not found`)
-  }
 
   const runtimeNotificationId = `${RUNTIME_NOTIFICATION_ID_TAG}-${nextNotificationId}`
 

--- a/src/utils/notification/index.ts
+++ b/src/utils/notification/index.ts
@@ -1,7 +1,5 @@
 export {
+  addNotification,
   defaultNotificationPreferences,
   preferencesForNotification,
-  addNotification,
 } from './helpers'
-// export * from './notificationTexts'
-// export * from './notificationLinks'

--- a/src/utils/overlay.ts
+++ b/src/utils/overlay.ts
@@ -345,16 +345,16 @@ export class EntityManagerOverlay {
   constructor(
     private em: EntityManager,
     private nextEntityIds: NextEntityId[],
-    private afterDbUpdte: (em: EntityManager) => Promise<void>
+    private afterDbUpdate: (em: EntityManager) => Promise<void>
   ) {}
 
-  public static async create(store: Store, afterDbUpdte: (em: EntityManager) => Promise<void>) {
+  public static async create(store: Store, afterDbUpdate: (em: EntityManager) => Promise<void>) {
     // FIXME: This is a little hacky, but we really need to access the underlying EntityManager
     const em = await (store as unknown as { em: () => Promise<EntityManager> }).em()
     // Add "admin" schema to search path in order to be able to access "hidden" entities
     await em.query('SET search_path TO admin,public')
     const nextEntityIds = await em.find(NextEntityId, {})
-    return new EntityManagerOverlay(em, nextEntityIds, afterDbUpdte)
+    return new EntityManagerOverlay(em, nextEntityIds, afterDbUpdate)
   }
 
   public totalCacheSize() {
@@ -400,6 +400,6 @@ export class EntityManagerOverlay {
         })
     )
     await this.em.save(nextIds)
-    await this.afterDbUpdte(this.em)
+    await this.afterDbUpdate(this.em)
   }
 }


### PR DESCRIPTION
# Context

While creating the runtime notifications [addRuntimeNotification](https://github.com/zeeshanakram3/orion/blob/master/src/utils/notification/helpers.ts#L181) function reads the nextEntityId for the new notification from the [db](https://github.com/zeeshanakram3/orion/blob/master/src/utils/notification/helpers.ts#L191). And, then use this _id_ to create a new entity in the overlay.

Now the problem is that if many concurrent notifications are being created e.g. `Promise.all([...])`. Then each concurrent call of `addRuntimeNotification` will read the same next entity ID from the db, and only one notification can be created.

# Fix

Instead of using db to get the next entity ID, read the ID form the overlay and then update it too, so the each concurrent `addRuntimeNotification` instance has access to the correct next entity ID.