### PR TITLE
Fix NFT sale proceeds not registering in CRT revenue account

### DIFF
--- a/src/mappings/content/nft.ts
+++ b/src/mappings/content/nft.ts
@@ -293,7 +293,7 @@ export async function processEnglishAuctionSettledEvent({
   // set last sale
   nft.lastSalePrice = winningBid.amount
   nft.lastSaleDate = new Date(block.timestamp)
-  await maybeIncreaseChannelCumulativeRevenueAfterNft(overlay, nft)
+  await maybeIncreaseChannelCumulativeRevenueAfterNft(overlay, nft, previousNftOwner)
 
   // add new event
   const event = overlay.getRepository(Event).new({
@@ -355,7 +355,7 @@ export async function processBidMadeCompletingAuctionEvent({
   // set last sale
   nft.lastSalePrice = winningBid.amount
   nft.lastSaleDate = new Date(block.timestamp)
-  await maybeIncreaseChannelCumulativeRevenueAfterNft(overlay, nft)
+  await maybeIncreaseChannelCumulativeRevenueAfterNft(overlay, nft, previousNftOwner)
 
   // add new event
   const event = overlay.getRepository(Event).new({
@@ -411,7 +411,7 @@ export async function processOpenAuctionBidAcceptedEvent({
   // set last sale
   nft.lastSalePrice = winningBid.amount
   nft.lastSaleDate = new Date(block.timestamp)
-  await maybeIncreaseChannelCumulativeRevenueAfterNft(overlay, nft)
+  await maybeIncreaseChannelCumulativeRevenueAfterNft(overlay, nft, previousNftOwner)
 
   // add new event
   const event = overlay.getRepository(Event).new({

--- a/src/mappings/content/utils.ts
+++ b/src/mappings/content/utils.ts
@@ -870,11 +870,14 @@ export function computeRoyalty(royaltyPct: number, price: bigint): bigint {
 
 export async function maybeIncreaseChannelCumulativeRevenueAfterNft(
   overlay: EntityManagerOverlay,
-  nft: Flat<OwnedNft>
+  nft: Flat<OwnedNft>,
+  previousNftOwner?: NftOwner
 ) {
   const video = await overlay.getRepository(Video).getByIdOrFail(nft.videoId)
   const channel = await overlay.getRepository(Channel).getByIdOrFail(assertNotNull(video.channelId))
-  if (nft.owner.isTypeOf === 'NftOwnerChannel') {
+  const nftOwnerType = previousNftOwner ? previousNftOwner.isTypeOf : nft.owner.isTypeOf
+
+  if (nftOwnerType === 'NftOwnerChannel') {
     increaseChannelCumulativeRevenue(channel, assertNotNull(nft.lastSalePrice))
   } else {
     if (nft.creatorRoyalty) {


### PR DESCRIPTION
Aims to fix the issue outlined here: https://github.com/Joystream/joystream/issues/5180

The problem was that the NFT ownership for the auction was updated before it was checked for in the `maybeIncreaseChannelCumulativeRevenueAfterNft`. This would make it always fail. Added the option to pass `previousNftOwner` to the function to circumvent this issue where necessary.

cc @Lezek123 