### PR TITLE
Adjust db logs configuration

### DIFF
--- a/archive/docker-compose.yml
+++ b/archive/docker-compose.yml
@@ -6,15 +6,20 @@ services:
     restart: unless-stopped
     volumes:
       - orion_archive_db_data:/var/lib/postgresql/data
+      - ./postgres.conf:/etc/postgresql/postgresql.conf
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: squid-archive
+    logging:
+      driver: 'local'
+      options:
+        max-size: '200m'
+        max-file: '10'
     ports:
       - '127.0.0.1:${DB_PORT}:${DB_PORT}'
       - '[::1]:${DB_PORT}:${DB_PORT}'
-    command: ['postgres', '-c', 'log_statement=all', '-p', '${DB_PORT}']
-
+    command: ['postgres', '-c', 'config_file=/etc/postgresql/postgresql.conf', '-p', '${DB_PORT}']
   ingest:
     container_name: orion_archive_ingest
     depends_on:

--- a/archive/postgres.conf
+++ b/archive/postgres.conf
@@ -1,0 +1,4 @@
+listen_addresses = '*'
+log_statement = mod
+log_min_duration_statement = 1000
+log_lock_waits = on

--- a/db/postgres.conf
+++ b/db/postgres.conf
@@ -1,5 +1,7 @@
 listen_addresses = '*'
-log_statement = all
+log_statement = mod
+log_min_duration_statement = 1000
+log_lock_waits = on
 autovacuum_analyze_scale_factor = 0.01
 shared_buffers=2GB
 jit=off

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,11 @@ services:
     environment:
       POSTGRES_DB: squid
       POSTGRES_PASSWORD: squid
+    logging:
+      driver: 'local'
+      options:
+        max-size: '200m'
+        max-file: '10'
     networks:
       - joystream_default
     ports:


### PR DESCRIPTION
- Only log [`mod` statements](https://www.postgresql.org/docs/current/runtime-config-logging.html#GUC-LOG-STATEMENT) (`INSERT`, `DELETE`, `UPDATE` etc.) and [statements that take longer than 1 second](https://www.postgresql.org/docs/current/runtime-config-logging.html#GUC-LOG-MIN-DURATION-STATEMENT).
- Set [`local`](https://docs.docker.com/engine/logging/drivers/local/) logging driver with log rotation in db docker services (`max 200 MB * 10 files = 2 GB`)
- Turn on `log_lock_waits`