### PR TITLE
4.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 4.3.0
+
+## Affected components:
+- Processor:
+    - **(M) `Content.EnglishAuctionSettled`** (event handler)
+    - **(M) `Content.BidMadeCompletingAuction`** (event handler)
+    - **(M) `Content.OpenAuctionBidAccepted`** (event handler)
+    - State importing
+- Export state script (`npm run offchain-state:export`)
+- Default `docker-compose.yml` and `postgres.conf` configuration
+
+## Changes
+
+- Fixed `Channel.cumulativeRevenue` calculation after NFT is sold on Open/English auction (https://github.com/Joystream/joystream/issues/5180)
+- Added missing data to exported state (https://github.com/Joystream/orion/pull/358):
+    - `CreatorToken.isFeatured` field
+    - `Video.includeInHomeFeed` field
+    - `UserInteractionCount` entity
+- Changed default database logging configuration to be more conservative (https://github.com/Joystream/orion/pull/357)
+- Changed default archive configuration to include `scan-max-value` (https://github.com/Joystream/orion/pull/355)
+
 # 4.2.0
 
 ## Affected components:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
     - `CreatorToken.isFeatured` field
     - `Video.includeInHomeFeed` field
     - `UserInteractionCount` entity
+- Fixed import logic (now runs BEFORE processing any block > `exportBlockNumber`. This prevents state inconsistency in case `exportBlockNumber` block does not have any relevant events and is therefore not processed by Orion)
 - Changed default database logging configuration to be more conservative (https://github.com/Joystream/orion/pull/357)
 - Changed default archive configuration to include `scan-max-value` (https://github.com/Joystream/orion/pull/355)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orion",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orion",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "hasInstallScript": true,
       "workspaces": [
         "network-tests"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orion",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "engines": {
     "node": ">=16"
   },


### PR DESCRIPTION
# 4.3.0

## Affected components:
- Processor:
    - **(M) `Content.EnglishAuctionSettled`** (event handler)
    - **(M) `Content.BidMadeCompletingAuction`** (event handler)
    - **(M) `Content.OpenAuctionBidAccepted`** (event handler)
    - State importing
- Export state script (`npm run offchain-state:export`)
- Default `docker-compose.yml` and `postgres.conf` configuration

## Changes

- Fixed `Channel.cumulativeRevenue` calculation after NFT is sold on Open/English auction (https://github.com/Joystream/joystream/issues/5180)
- Added missing data to exported state (https://github.com/Joystream/orion/pull/358):
    - `CreatorToken.isFeatured` field
    - `Video.includeInHomeFeed` field
    - `UserInteractionCount` entity
- Fixed import logic (now runs BEFORE processing any block > `exportBlockNumber`. This prevents state inconsistency in case `exportBlockNumber` block does not have any relevant events and is therefore not processed by Orion)
- Changed default database logging configuration to be more conservative (https://github.com/Joystream/orion/pull/357)
- Changed default archive configuration to include `scan-max-value` (https://github.com/Joystream/orion/pull/355)