### PR TITLE
4.4.1: Fix data mocking scripts (docker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 4.4.1
+## Affected components:
+- Scripts:
+    - **(M)** `scripts/generateMockData.ts`
+    - **(M)** `scripts/seedDb.ts`
+
+- Fixed a bug when running `npm run generate:mock-data` from within docker container (missing `schema.graphql`).
+- Fixed invalid error message when input/output path not provided in `generate:mock-data` / `db:seed` scripts.
+
 # 4.4.0
 
 ## Affected components:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orion",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orion",
-      "version": "4.4.0",
+      "version": "4.4.1",
       "hasInstallScript": true,
       "workspaces": [
         "network-tests"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orion",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "engines": {
     "node": ">=16"
   },

--- a/src/scripts/generateMockData.ts
+++ b/src/scripts/generateMockData.ts
@@ -3,7 +3,7 @@ import _ from 'lodash'
 import path from 'path'
 import assert from 'node:assert'
 import fs from 'fs/promises'
-import { loadModel } from '@subsquid/openreader/lib/tools'
+import { loadModel, resolveGraphqlSchema } from '@subsquid/openreader/lib/tools'
 import {
   Enum,
   EnumPropType,
@@ -17,7 +17,7 @@ import {
 import * as model from '../model'
 import { globalEm } from '../utils/globalEm'
 
-const subsquidModel = loadModel(path.join(__dirname, '../../schema.graphql'))
+const subsquidModel = loadModel(resolveGraphqlSchema(path.join(__dirname, '../..')))
 
 type AnyEntity = { id: string }
 
@@ -162,7 +162,7 @@ const excludedEntities = new Set(['NextEntityId', 'OrionOffchainCursor'])
 
 export async function generateMockData(em: EntityManager) {
   const outputPath = process.argv[2]
-  if (!outputPath && !outputPath.endsWith('.json')) {
+  if (!outputPath || !outputPath.endsWith('.json')) {
     throw new Error('Provide output path (.json) as first argument!')
   }
   //   Get a list of all entities from the metadata
@@ -178,6 +178,7 @@ export async function generateMockData(em: EntityManager) {
     e,
   ])
   await fs.writeFile(outputPath, JSON.stringify(mockedRecords, null, 2))
+  console.log(`Saved mock data in ${outputPath}`)
 }
 
 async function main() {

--- a/src/scripts/seedDb.ts
+++ b/src/scripts/seedDb.ts
@@ -16,7 +16,7 @@ type AnyEntityName = {
 
 export async function seed(em: EntityManager) {
   const inputPath = process.argv[2]
-  if (!inputPath && !inputPath.endsWith('.json')) {
+  if (!inputPath || !inputPath.endsWith('.json')) {
     throw new Error('Provide input path (.json) as first argument!')
   }
   const input: [AnyEntityName, Record<string, unknown>][] = JSON.parse(


### PR DESCRIPTION
# 4.4.1
## Affected components:
- Scripts:
    - **(M)** `scripts/generateMockData.ts`
    - **(M)** `scripts/seedDb.ts`

- Fixed a bug when running `npm run generate:mock-data` from within docker container (missing `schema.graphql`).
- Fixed invalid error message when input/output path not provided in `generate:mock-data` / `db:seed` scripts.